### PR TITLE
Add ability to publish to local Maven repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,12 +6,14 @@ plugins {
     id 'java'
     id 'war'
     id 'com.github.jk1.dependency-license-report' version '1.16'
+    id 'maven-publish'
 }
 
 defaultTasks 'build'
 build.dependsOn 'distZip'
 
 version = '1.63'
+group = 'de.bottlecaps.rr'
 def buildTime = new Date()
 
 def generatedSrc = "$buildDir/generated-src/main/java"
@@ -152,5 +154,18 @@ task distZip(type:JavaExec) {
 
     doFirst {
       mkdir workingDir
+    }
+}
+
+publishing {
+    publications {
+        jar(MavenPublication) {
+            artifactId = 'rr-lib'
+            from components.java
+        }
+        war(MavenPublication) {
+            artifactId = 'rr-webapp'
+            from components.web
+        }
     }
 }


### PR DESCRIPTION
This PR allows developers to publish RR to their local Maven repository directory.

In another (locally built) project, one can then declare a dependency Maven/Gradle dependency on `de.bottlecaps.rr:rr-lib:1.63`.

Note: my end goal is to create an RR Maven plugin. For this I will need additional (mostly harmless) changes, but I'd like to submit separate PRs for those.