### PR TITLE
Replace defunct JCenter with Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'war'
     id 'com.github.jk1.dependency-license-report' version '1.16'
     id 'maven-publish'
+    id 'signing'
 }
 
 defaultTasks 'build'
@@ -27,7 +28,7 @@ sourceSets {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
@@ -80,6 +81,11 @@ public class RailroadVersion
 
 compileJava {
     dependsOn generateSrc
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
 task generateLicense {
@@ -157,15 +163,67 @@ task distZip(type:JavaExec) {
     }
 }
 
+ext.isReleaseVersion = !version.endsWith("-SNAPSHOT")
+
+void configureMetadata(MavenPublication mavenPublication) {
+    configure (mavenPublication) {
+        pom {
+            name = groupId + ':' + artifactId
+            description = 'Railroad diagram generator'
+            url = 'https://bottlecaps.de/rr/ui'
+            licenses {
+                license {
+                    name = 'Apache-2.0'
+                    url = 'https://opensource.org/licenses/Apache-2.0'
+                }
+            }
+            developers {
+                developer {
+                    name = 'Gunther Rademacher'
+                    email = 'grd@gmx.net'
+                    organization = 'Gunther Rademacher'
+                    organizationUrl = 'https://bottlecaps.de/'
+                }
+            }
+            scm {
+                connection = 'git@github.com:GuntherRademacher/rr.git'
+                developerConnection = 'git@github.com:GuntherRademacher/rr.git'
+                url = 'https://github.com/GuntherRademacher/rr'
+            }
+        }
+    }
+}
+
 publishing {
+    repositories {
+        maven {
+            def releaseRepo = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            def snapshotRepo = "https://oss.sonatype.org/content/repositories/snapshots/"
+            url = isReleaseVersion ? releaseRepo : snapshotRepo
+            credentials {
+                username = project.hasProperty('ossrhUsername') ? ossrhUsername : "Unknown user"
+                password = project.hasProperty('ossrhPassword') ? ossrhPassword : "Unknown password"
+            }
+        }
+    }
+
     publications {
         jar(MavenPublication) {
             artifactId = 'rr-lib'
             from components.java
+            configureMetadata delegate
         }
         war(MavenPublication) {
             artifactId = 'rr-webapp'
             from components.web
+            configureMetadata delegate
         }
     }
+}
+
+signing {
+    sign publishing.publications.jar
+}
+tasks.withType(Sign) {
+    onlyIf { isReleaseVersion }
 }


### PR DESCRIPTION
Following up on #12 and #14, this PR should complete the work of publishing RR as a reusable library.

As JCenter was [turned into a read-only archive](https://blog.gradle.org/jcenter-shutdown) in 2021, RR needs a new distribution repository. Using Maven Central has the added benefit that developers will not have to configure anything to consume the artifact, but just add a dependency to their project. The standard way to do this is to use Sonatype OSSRH (OSS Repository Hosting).

With this PR, the build should set all fields [required by the OSSRH guidelines](https://central.sonatype.org/publish/requirements/). The approach taken is based on [this article](https://dev.to/kengotoda/deploying-to-ossrh-with-gradle-in-2020-1lhi).

Before merging this, do the following:

1. Set up an OSSRH account and repository following [the official guide](https://central.sonatype.org/publish/publish-guide/).
2. OSSRH may tell you to use a different server. If that's the case you need to adapt `releaseRepo` and `snapshotRepo` in the Gradle file accordingly.
3. Put your credentials for GPG (`signing.keyId`, `signing.password` and `signing.secretKeyRingFile`) and OSSRH (`ossrhUsername` and `ossrhPassword`) into `~/.gradle/gradle.properties`.
4. Perform a publish with a snapshot version. Log in to OSSRH to verify the artifacts were uploaded.
    - Note: while snapshots can be consumed by developers (via the special OSSRH snapshots repository), unlike releases they do not get pushed to Maven Central.

After merging this, you should be able to publish a `master` build (non-snapshot versions) to OSSRH's Nexus. There, you can log in, find the _staging repository_ for your build and trigger the _release_ process which includes automated requirements validation. If successful, the build will be propagated to Maven Central in a matter of hours.

Let me know if you need any assistance with this.